### PR TITLE
Update to use https://golang.org/dl for binary releases

### DIFF
--- a/src/sdk.go
+++ b/src/sdk.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	golangDownloadURL  string = "https://dl.google.com/go"
+	golangDownloadURL  string = "https://golang.org/dl"
 	sdkDirName         string = "sdk"
 	sdkUsedDirName     string = "current"
 	sdkDownloadDirName string = ".downloads"


### PR DESCRIPTION
Golang binaries have been moved to golang.org